### PR TITLE
Optimize CI triggers to only run on successful merges to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,12 +3,13 @@ name: CI
 on:
   push:
     branches: [ main ]
-  pull_request:
-    branches: [ main ]
+  # Only run on successful merges to main, not on PRs
 
 jobs:
   test:
     runs-on: ubuntu-latest
+    # Only run on merge commits (from git finish workflow), not direct pushes
+    if: contains(github.event.head_commit.message, 'Merge pull request') || contains(github.event.head_commit.message, '#')
 
     services:
       mysql:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,13 +2,14 @@ name: Deploy to Production
 
 on:
   push:
-    branches: [ main ]
-    tags: [ 'v*' ]
+    branches: [ main ]  # Only on successful merges to main
+    tags: [ 'v*' ]     # Or on version tags
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
+    # Only run on merge commits to main or version tags
+    if: (github.ref == 'refs/heads/main' && (contains(github.event.head_commit.message, 'Merge pull request') || contains(github.event.head_commit.message, '#'))) || startsWith(github.ref, 'refs/tags/v')
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
Optimize CI triggers to only run on successful merges to main

## Changes
- .github/workflows/ci.yml
- .github/workflows/deploy.yml

🤖 Generated with [Claude Code](https://claude.ai/code)