### PR TITLE
Restore sidebar navigation by reverting to navigationItems - all links and icons now working except Home icon due to Filament framework behavior

### DIFF
--- a/plugins/pages/src/Providers/PagesPanelProvider.php
+++ b/plugins/pages/src/Providers/PagesPanelProvider.php
@@ -34,7 +34,7 @@ class PagesPanelProvider extends PanelProvider
                 \FilaMan\Pages\Filament\Pages\PagesList::class,
                 \FilaMan\Pages\Filament\Pages\DynamicPage::class,
             ])
-            ->navigationGroups($navigationService->getNavigationGroups())
+            ->navigationItems($navigationService->getNavigationItems())
             ->widgets([
                 // No widgets needed for pages panel
             ])


### PR DESCRIPTION
## Summary
Restore sidebar navigation by reverting to navigationItems - all links and icons now working except Home icon due to Filament framework behavior

## Changes
- plugins/pages/src/Providers/PagesPanelProvider.php

🤖 Generated with [Claude Code](https://claude.ai/code)