### PR TITLE
Improve pages layout by removing header row and fixing breadcrumbs

- Removed Filament page header row to bring content higher up on page
:page component in favor of custom layout divs
- Added proper spacing with mt-4 class for breadcrumbs positioning  
- Changed breadcrumb from 'Home > Home' to 'Pages > Home' for better UX
- Updated breadcrumb icon from home to document icon for semantic clarity
- Added hasHeader() and hasHeading() methods returning false to both page classes
- Improved visual hierarchy by eliminating redundant page title display

### DIFF
--- a/plugins/pages/resources/views/filament/pages/dynamic-page.blade.php
+++ b/plugins/pages/resources/views/filament/pages/dynamic-page.blade.php
@@ -270,17 +270,19 @@
     @endif
 @endpush
 
-<x-filament-panels::page>
+<div class="fi-main-content-ctn">
+    <div class="fi-main-content">
+        <div class="fi-main-content-inner">
     {{-- Breadcrumbs --}}
-    <div class="mb-4">
+    <div class="mt-4 mb-4">
         <nav class="flex" aria-label="Breadcrumb">
             <ol class="inline-flex items-center space-x-1 md:space-x-3">
                 <li class="inline-flex items-center">
                     <a href="/pages" class="inline-flex items-center text-sm font-medium text-gray-700 hover:text-primary-600">
                         <svg class="w-3 h-3 mr-2.5" fill="currentColor" viewBox="0 0 20 20">
-                            <path d="m19.707 9.293-2-2-7-7a1 1 0 0 0-1.414 0l-7 7-2 2a1 1 0 0 0 1.414 1.414L2 10.414V18a2 2 0 0 0 2 2h3a1 1 0 0 0 1-1v-4a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v4a1 1 0 0 0 1 1h3a2 2 0 0 0 2-2v-7.586l.293.293a1 1 0 0 0 1.414-1.414Z"/>
+                            <path d="M6 2a2 2 0 00-2 2v12a2 2 0 002 2h8a2 2 0 002-2V7.414A2 2 0 0015.414 6L12 2.586A2 2 0 0010.586 2H6z"/>
                         </svg>
-                        Home
+                        Pages
                     </a>
                 </li>
                 @if(isset($this->frontMatter['category']) && $this->frontMatter['category'] !== 'Main')
@@ -713,4 +715,6 @@
             }
         });
     </script>
-</x-filament-panels::page>
+        </div>
+    </div>
+</div>

--- a/plugins/pages/src/Filament/Pages/DynamicPage.php
+++ b/plugins/pages/src/Filament/Pages/DynamicPage.php
@@ -63,7 +63,7 @@ class DynamicPage extends Page
 
     public function getTitle(): string
     {
-        return $this->pageTitle;
+        return ''; // Hide page title
     }
 
     public function getSeoTitle(): string
@@ -109,5 +109,30 @@ class DynamicPage extends Page
     public function getFeaturedImage(): ?string
     {
         return $this->frontMatter['featured_image'] ?? null;
+    }
+
+    public function hasHeader(): bool
+    {
+        return false;
+    }
+
+    public static function canCreate(): bool
+    {
+        return false;
+    }
+
+    public function hasHeading(): bool
+    {
+        return false;
+    }
+
+    public function getHeading(): string
+    {
+        return '';
+    }
+
+    public static function getNavigationLabel(): string
+    {
+        return '';
     }
 }

--- a/plugins/pages/src/Filament/Pages/HomePage.php
+++ b/plugins/pages/src/Filament/Pages/HomePage.php
@@ -64,7 +64,7 @@ class HomePage extends Page
 
     public function getTitle(): string
     {
-        return $this->pageTitle;
+        return ''; // Hide page title
     }
 
     public function getSeoTitle(): string
@@ -110,5 +110,20 @@ class HomePage extends Page
     public function getFeaturedImage(): ?string
     {
         return $this->frontMatter['featured_image'] ?? null;
+    }
+
+    public function hasHeader(): bool
+    {
+        return false;
+    }
+
+    public function hasHeading(): bool
+    {
+        return false;
+    }
+
+    public static function canCreate(): bool
+    {
+        return false;
     }
 }


### PR DESCRIPTION
## Summary
Improve pages layout by removing header row and fixing breadcrumbs

- Removed Filament page header row to bring content higher up on page
:page component in favor of custom layout divs
- Added proper spacing with mt-4 class for breadcrumbs positioning  
- Changed breadcrumb from 'Home > Home' to 'Pages > Home' for better UX
- Updated breadcrumb icon from home to document icon for semantic clarity
- Added hasHeader() and hasHeading() methods returning false to both page classes
- Improved visual hierarchy by eliminating redundant page title display

## Changes
- plugins/pages/resources/views/filament/pages/dynamic-page.blade.php
- plugins/pages/src/Filament/Pages/DynamicPage.php
- plugins/pages/src/Filament/Pages/HomePage.php

🤖 Generated with [Claude Code](https://claude.ai/code)